### PR TITLE
Use an old version of the ruby uninstall script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
     - MACOS=1
 
 before_install:
-  - curl -fsSOL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh
-  - sudo /bin/bash uninstall.sh --force
-  - rm uninstall.sh
+  - curl -fsSOL https://raw.githubusercontent.com/Homebrew/install/6f9b04355b11f6849fed761725a1f10cb326e979/uninstall
+  - sudo ruby uninstall --force
+  - rm uninstall
   - hash -r
 
 before_script:

--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -31,7 +31,7 @@ class Thrift < Formula
   deprecated_option "with-python" => "with-python@2"
 
   depends_on "bison" => :build
-  depends_on "boost"
+  depends_on "boost" => :build
   depends_on "openssl"
   depends_on "libevent" => :optional
   depends_on "python@2" => :optional


### PR DESCRIPTION
We do not use MacOS 10.15 in CI anyway.

This reverts commit eadc6e0bad5d996ed98ec74b0f914d805401ed7f.