### PR TITLE
Static build of aws-sdk-cpp with unity cmake

### DIFF
--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -6,9 +6,10 @@ class AwsSdkCpp < Formula
   head "https://github.com/aws/aws-sdk-cpp.git"
 
   bottle do
-    sha256 "5b894fdbfc1d2d2b6c54a0a8fe2d53953b43cafd6ec93741fc4235ac9ee406e4" => :catalina
-    sha256 "2d9f1f2aabe30948e7751fe97f86307ae00cd6db6d4d0b7b892e01acaedba839" => :mojave
-    sha256 "043111013037afbbc86d155d45a2dcb56c213577faa61839b79ee6a76fb8e00e" => :high_sierra
+    cellar :any_skip_relocation
+    sha256 "d17d2982db9a623c2e12526cb339647f462609efb7c709fcbdb0102f4cea00ec" => :high_sierra
+    sha256 "6a620b49a387017da90670bc8661ad31e051fc71c445ab053b4dde78cb195558" => :el_capitan
+    root_url "https://autobrew.github.io/bottles"
   end
 
   depends_on "cmake" => :build

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -15,7 +15,8 @@ class AwsSdkCpp < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_ONLY=s3;core;config", "-DENABLE_UNITY_BUILD=ON",  *std_cmake_args
+      ENV["CPATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
+      system "cmake", "..", "-DAUTORUN_UNIT_TESTS=OFF", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_ONLY=s3;core;config", "-DENABLE_UNITY_BUILD=ON",  *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -15,8 +15,7 @@ class AwsSdkCpp < Formula
 
   def install
     mkdir "build" do
-      ENV["CPATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
-      system "cmake", "..", "-DAUTORUN_UNIT_TESTS=OFF", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_ONLY=s3;core;config", "-DENABLE_UNITY_BUILD=ON",  *std_cmake_args
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_ONLY=s3;core;config", "-DENABLE_UNITY_BUILD=ON",  *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -1,31 +1,21 @@
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  # aws-sdk-cpp should only be updated every 10 releases on multiples of 10
-  url "https://github.com/aws/aws-sdk-cpp/archive/1.5.10.tar.gz"
-  sha256 "b10d4d643cf88fd44d6ac5f36a0c473105cc8bfdc7ea1a8d9b67c29efb875885"
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.7.365.tar.gz"
+  sha256 "95e3f40efaea7b232741bfb76c54c9507c02631edfc198720b0e84be0ebb5e9d"
   head "https://github.com/aws/aws-sdk-cpp.git"
 
   bottle do
-    cellar :any
-    sha256 "df342149e5aa1e69b5c289a686c67817e0d4fabc1ab936be66ac172816edcc6a" => :mojave
-    sha256 "38cb9d8a2c0881f66daca887582deaf7c7dc5b34f63576c42616cc944ab33e2d" => :high_sierra
-    sha256 "0cd5ada4bc0ce1b16984afcd191e6bb080c0e13445752b30744e140262c81308" => :sierra
-    sha256 "1a7b7a2ed0aaee7d51ba0168a44d50076459e8e84dbc8fd370010bc30f010870" => :el_capitan
+    sha256 "5b894fdbfc1d2d2b6c54a0a8fe2d53953b43cafd6ec93741fc4235ac9ee406e4" => :catalina
+    sha256 "2d9f1f2aabe30948e7751fe97f86307ae00cd6db6d4d0b7b892e01acaedba839" => :mojave
+    sha256 "043111013037afbbc86d155d45a2dcb56c213577faa61839b79ee6a76fb8e00e" => :high_sierra
   end
-
-  option "with-static", "Build with static linking"
-  option "without-http-client", "Don't include the libcurl HTTP client"
 
   depends_on "cmake" => :build
 
   def install
-    args = std_cmake_args
-    args << "-DSTATIC_LINKING=1" if build.with? "static"
-    args << "-DNO_HTTP_CLIENT=1" if build.without? "http-client"
-
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_ONLY=s3;core;config", "-DENABLE_UNITY_BUILD=ON",  *std_cmake_args
       system "make"
       system "make", "install"
     end
@@ -43,7 +33,7 @@ class AwsSdkCpp < Formula
           return 0;
       }
     EOS
-    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laws-cpp-sdk-core",
+    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laws-cpp-sdk-core", "-lcurl",
            "-o", "test"
     system "./test"
   end

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -1,8 +1,8 @@
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/1.7.365.tar.gz"
-  sha256 "95e3f40efaea7b232741bfb76c54c9507c02631edfc198720b0e84be0ebb5e9d"
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.7.364.tar.gz"
+  sha256 "05ed242a601b614eb46e8e32b56367fc3f195ff3b63337eb928a72f4776ee495"
   head "https://github.com/aws/aws-sdk-cpp.git"
 
   bottle do


### PR DESCRIPTION
Let's try with a newer cmake, and unity build.
Replaces https://github.com/autobrew/homebrew-core/pull/2
@nealrichardson