### PR TITLE
Bump aws-sdk-cpp version

### DIFF
--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -1,8 +1,8 @@
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/1.7.364.tar.gz"
-  sha256 "05ed242a601b614eb46e8e32b56367fc3f195ff3b63337eb928a72f4776ee495"
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.8.55.tar.gz"
+  sha256 "6295e05b44d365e15735f28cd003a01913e302bcd3ba659ef26759e650f412e9"
   head "https://github.com/aws/aws-sdk-cpp.git"
 
   bottle do


### PR DESCRIPTION
There are some useful features around AWS region detection in 1.8 that would be nice to take advantage of: https://aws.amazon.com/blogs/developer/aws-sdk-for-c-version-1-8-developer-preview/