### PR TITLE
update freetype to match cran version

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -1,9 +1,9 @@
 class Freetype < Formula
   desc "Software library to render fonts"
   homepage "https://www.freetype.org/"
-  url "https://downloads.sourceforge.net/project/freetype/freetype2/2.9.1/freetype-2.9.1.tar.bz2"
-  mirror "https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.bz2"
-  sha256 "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d"
+  url "https://downloads.sourceforge.net/project/freetype/freetype2/2.10.0/freetype-2.10.0.tar.bz2"
+  mirror "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.0.tar.bz2"
+  sha256 "fccc62928c65192fff6c98847233b28eb7ce05f12d2fea3f6cc90e8b4e5fbe06"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Package systemfonts statically links against the cran freetype, and then exports a C api. So perhaps it's safer to match the version, although I don't think it should matter.