### PR TITLE
Bump zstd to 1.5.0

### DIFF
--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -1,8 +1,8 @@
 class Zstd < Formula
   desc "Zstandard is a real-time compression algorithm"
   homepage "http://zstd.net/"
-  url "https://github.com/facebook/zstd/archive/v1.3.5.tar.gz"
-  sha256 "d6e1559e4cdb7c4226767d4ddc990bff5f9aab77085ff0d0490c828b025e2eea"
+  url "https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"
+  sha256 "5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94"
 
   bottle do
     cellar :any

--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -1,7 +1,7 @@
 class Zstd < Formula
   desc "Zstandard is a real-time compression algorithm"
   homepage "http://zstd.net/"
-  url "https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"
+  url "https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-1.5.0.tar.gz"
   sha256 "5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94"
 
   bottle do


### PR DESCRIPTION
Current autobrew zstd is on 1.3.5, and in https://github.com/apache/arrow/pull/10717 we now depend on a feature that was added in 1.3.6. This PR just bumps zstd to the latest release.