### PR TITLE
apache-arrow 12.0.1

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -1,10 +1,10 @@
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"
   homepage "https://arrow.apache.org/"
-  url "https://downloads.apache.org/arrow/arrow-12.0.0/apache-arrow-12.0.0.tar.gz"
+  url "https://downloads.apache.org/arrow/arrow-12.0.1/apache-arrow-12.0.1.tar.gz"
   # Uncomment and update to test on a release candidate 
-  mirror "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-12.0.0-rc0/apache-arrow-12.0.0.tar.gz"
-  sha256 "ddd8347882775e53af7d0965a1902b7d8fcd0a030fd14f783d4f85e821352d52"
+  mirror "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-12.0.1-rc1/apache-arrow-12.0.1.tar.gz"
+  sha256 "3481c411393aa15c75e88d93cf8315faf7f43e180fe0790128d3840d417de858"
 
   bottle do
     cellar :any

--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -4,7 +4,7 @@ class ApacheArrow < Formula
   url "https://downloads.apache.org/arrow/arrow-12.0.1/apache-arrow-12.0.1.tar.gz"
   # Uncomment and update to test on a release candidate 
   mirror "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-12.0.1-rc1/apache-arrow-12.0.1.tar.gz"
-  sha256 "3481c411393aa15c75e88d93cf8315faf7f43e180fe0790128d3840d417de858"
+  sha256 "55fe1d17a3c2121b39bd71d7fc61d1053b183fa3bb5982a76d3c2b3ac5fb4aca"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This update is for the 12.0.1 release candidate - this is still being voted on.

FYI, we have had issues with the latest homebrew version of protobuf, so wasn't sure if we need to add `-DProtobuf_SOURCE=BUNDLED` below, similarly to: https://lists.apache.org/thread/b91oj63w3642wfv6t3wfrdztsyftvgqx